### PR TITLE
(feat) lab order actions  - Add order-actions-slot and switches icons for overflow menu 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,6 @@ import {
 } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
 import { createHomeDashboardLink } from "./components/create-dashboard-link.component";
-import pickLabRequestButtonComponent from "./order-actions/pick-lab-request.component";
-import rejectOrderButtonComponent from "./order-actions/reject-order.component";
 
 import { createDashboardLink } from "@openmrs/esm-patient-common-lib";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import {
 } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
 import { createHomeDashboardLink } from "./components/create-dashboard-link.component";
+import pickLabRequestButtonComponent from "./order-actions/pick-lab-request.component";
+import rejectOrderButtonComponent from "./order-actions/reject-order.component";
+
 import { createDashboardLink } from "@openmrs/esm-patient-common-lib";
 
 const moduleName = "@ugandaemr/esm-laboratory-app";
@@ -84,6 +87,16 @@ export const reviewItemDialog = getAsyncLifecycle(
 
 export const rejectOrderDialog = getAsyncLifecycle(
   () => import("./reject-order/reject-order-dialog.component"),
+  options
+);
+
+export const pickLabRequestButton = getAsyncLifecycle(
+  () => import("./queue-list/pick-lab-request-menu.component"),
+  options
+);
+
+export const rejectOrderButton = getAsyncLifecycle(
+  () => import("./order-actions/reject-order.component"),
   options
 );
 

--- a/src/order-actions/reject-order.component.tsx
+++ b/src/order-actions/reject-order.component.tsx
@@ -13,7 +13,7 @@ const RejectOrderOverflowMenuItem: React.FC<
 > = ({ order }) => {
   const { t } = useTranslation();
 
-  const handleRejectOrder = useCallback(() => {
+  const handleRejectOrderModel = useCallback(() => {
     const dispose = showModal("reject-order-dialog", {
       closeModal: () => dispose(),
       order,
@@ -22,7 +22,7 @@ const RejectOrderOverflowMenuItem: React.FC<
   return (
     <OverflowMenuItem
       itemText={t("rejectOrder", "Reject Order")}
-      onClick={handleRejectOrder}
+      onClick={handleRejectOrderModel}
       style={{
         maxWidth: "100vw",
       }}

--- a/src/order-actions/reject-order.component.tsx
+++ b/src/order-actions/reject-order.component.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback } from "react";
+import { OverflowMenuItem, OverflowMenu } from "@carbon/react";
+import { useTranslation } from "react-i18next";
+import { showModal } from "@openmrs/esm-framework";
+import { Result } from "../work-list/work-list.resource";
+
+interface RejectOrderOverflowMenuItemProps {
+  order: Result;
+}
+
+const RejectOrderOverflowMenuItem: React.FC<
+  RejectOrderOverflowMenuItemProps
+> = ({ order }) => {
+  const { t } = useTranslation();
+
+  const handleRejectOrder = useCallback(() => {
+    const dispose = showModal("reject-order-dialog", {
+      closeModal: () => dispose(),
+      order,
+    });
+  }, [order]);
+  return (
+    <OverflowMenuItem
+      itemText={t("rejectOrder", "Reject Order")}
+      onClick={handleRejectOrder}
+      style={{
+        maxWidth: "100vw",
+      }}
+      isDelete={true}
+      hasDivider
+    />
+  );
+};
+
+export default RejectOrderOverflowMenuItem;

--- a/src/queue-list/laboratory-patient-list.component.tsx
+++ b/src/queue-list/laboratory-patient-list.component.tsx
@@ -26,10 +26,11 @@ import {
   DatePicker,
   DatePickerInput,
 } from "@carbon/react";
-import { TrashCan } from "@carbon/react/icons";
+import { TrashCan, OverflowMenuVertical } from "@carbon/react/icons";
 
 import { useTranslation } from "react-i18next";
 import {
+  ExtensionSlot,
   age,
   formatDate,
   formatDatetime,
@@ -41,7 +42,7 @@ import {
 import styles from "./laboratory-queue.scss";
 import { getStatusColor } from "../utils/functions";
 import { Result, useGetOrdersWorklist } from "../work-list/work-list.resource";
-import { Order } from "../types/patient-queues";
+import OrderCustomOverflowMenuComponent from "../ui-components/overflow-menu.component";
 
 interface LaboratoryPatientListProps {}
 
@@ -67,38 +68,6 @@ const LaboratoryPatientList: React.FC<LaboratoryPatientListProps> = () => {
     results: paginatedWorklistQueueEntries,
     currentPage,
   } = usePagination(workListEntries, currentPageSize);
-
-  // const RejectOrder: React.FC<RejectOrderProps> = ({ order }) => {
-  //   const launchRejectOrderModal = useCallback(() => {
-  //     const dispose = showModal("reject-order-dialog", {
-  //       closeModal: () => dispose(),
-  //       order,
-  //     });
-  //   }, [order]);
-  //   return (
-  //     <Button
-  //       kind="ghost"
-  //       onClick={launchRejectOrderModal}
-  //       renderIcon={(props) => <TrashCan size={16} {...props} />}
-  //     />
-  //   );
-  // };
-
-  const handleRejectOrder = useCallback((order: Result) => {
-    const dispose = showModal("reject-order-dialog", {
-      closeModal: () => dispose(),
-      order,
-    });
-  }, []);
-
-  const launchPickLabRequestQueueModal = useCallback((order: Order) => {
-    const dispose = showModal("add-to-worklist-dialog", {
-      closeModal: () => dispose(),
-
-      order,
-    });
-  }, []);
-
   // get picked orders
   let columns = [
     { id: 0, header: t("date", "Date"), key: "date" },
@@ -153,31 +122,22 @@ const LaboratoryPatientList: React.FC<LaboratoryPatientListProps> = () => {
         actions: {
           content: (
             <>
-              <OverflowMenu
-                flipped={document?.dir === "rtl"}
-                aria-label="Actions menu"
-                floatingMenu
+              <OrderCustomOverflowMenuComponent
+                menuTitle={
+                  <>
+                    <OverflowMenuVertical
+                      size={16}
+                      style={{ marginLeft: "0.3rem" }}
+                    />
+                  </>
+                }
               >
-                <OverflowMenuItem
-                  itemText={t("pickLabRequest", "Pick Lab Request")}
-                  requireTitle
-                  onClick={() =>
-                    launchPickLabRequestQueueModal(
-                      paginatedWorklistQueueEntries[index]
-                    )
-                  }
+                <ExtensionSlot
+                  className={styles.menuLink}
+                  state={{ order: paginatedWorklistQueueEntries[index] }}
+                  name="order-actions-slot"
                 />
-                <OverflowMenuItem
-                  className={styles.menuItem}
-                  id="discontinue"
-                  itemText={t("rejectOrder", "Reject Order")}
-                  onClick={() =>
-                    handleRejectOrder(paginatedWorklistQueueEntries[index])
-                  }
-                  isDelete={true}
-                  hasDivider
-                />
-              </OverflowMenu>
+              </OrderCustomOverflowMenuComponent>
             </>
           ),
         },

--- a/src/queue-list/pick-lab-request-menu.component.tsx
+++ b/src/queue-list/pick-lab-request-menu.component.tsx
@@ -1,11 +1,8 @@
-import { Button, Tooltip } from "@carbon/react";
-import { Notification } from "@carbon/react/icons";
-
+import { OverflowMenuItem } from "@carbon/react";
 import { showModal } from "@openmrs/esm-framework";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { MappedPatientQueueEntry } from "./laboratory-patient-list.resource";
-import { Encounter, Order } from "../types/patient-queues";
+import { Order } from "../types/patient-queues";
 
 interface PickLabRequestActionMenuProps {
   order: Order;
@@ -17,7 +14,7 @@ const PickLabRequestActionMenu: React.FC<PickLabRequestActionMenuProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const launchPickLabRequestQueueModal = useCallback(() => {
+  const launchPickLabRequestModal = useCallback(() => {
     const dispose = showModal("add-to-worklist-dialog", {
       closeModal: () => dispose(),
 
@@ -26,11 +23,12 @@ const PickLabRequestActionMenu: React.FC<PickLabRequestActionMenuProps> = ({
   }, [order]);
 
   return (
-    <Button
-      kind="ghost"
-      onClick={launchPickLabRequestQueueModal}
-      iconDescription={t("pickRequest", "Pick Lab Request ")}
-      renderIcon={(props) => <Notification size={16} {...props} />}
+    <OverflowMenuItem
+      itemText={t("pickLabRequest", "Pick Lab Request")}
+      onClick={launchPickLabRequestModal}
+      style={{
+        maxWidth: "100vw",
+      }}
     />
   );
 };

--- a/src/routes.json
+++ b/src/routes.json
@@ -67,6 +67,16 @@
     {
       "name" : "reject-order-dialog",
       "component": "rejectOrderDialog"
+    },
+    {
+      "name": "pick-lab-request-button",
+      "component": "pickLabRequestButton",
+      "slot": "order-actions-slot"
+    },
+    {
+      "name": "reject-order-button",
+      "component": "rejectOrderButton",
+      "slot": "order-actions-slot"
     }
   ]
 }

--- a/src/ui-components/overflow-menu.component.tsx
+++ b/src/ui-components/overflow-menu.component.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import classNames from "classnames";
+import { useLayoutType } from "@openmrs/esm-framework";
+import styles from "./overflow-menu.scss";
+
+interface OrderCustomOverflowMenuComponentProps {
+  menuTitle: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const OrderCustomOverflowMenuComponent: React.FC<
+  OrderCustomOverflowMenuComponentProps
+> = ({ children, menuTitle }) => {
+  const [showMenu, setShowMenu] = useState(false);
+  const isTablet = useLayoutType() === "tablet";
+  const wrapperRef = useRef(null);
+
+  const toggleShowMenu = useCallback(() => setShowMenu((state) => !state), []);
+
+  useEffect(() => {
+    /**
+     * Toggle showMenu if clicked on outside of element
+     */
+    function handleClickOutside(event: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setShowMenu(false);
+      }
+    }
+
+    // Bind the event listener
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [wrapperRef]);
+
+  return (
+    <div
+      data-overflow-menu
+      className={classNames("cds--overflow-menu", styles.container)}
+      ref={wrapperRef}
+    >
+      <button
+        className={classNames(
+          "cds--btn",
+          "cds--btn--ghost",
+          "cds--overflow-menu__trigger",
+          { "cds--overflow-menu--open": showMenu },
+          styles.overflowMenuButton
+        )}
+        aria-haspopup="true"
+        aria-expanded={showMenu}
+        id="custom-actions-overflow-menu-trigger"
+        aria-controls="custom-actions-overflow-menu"
+        onClick={toggleShowMenu}
+      >
+        {menuTitle}
+      </button>
+      <div
+        className={classNames(
+          "cds--overflow-menu-options",
+          "cds--overflow-menu--flip",
+          styles.menu,
+          {
+            [styles.show]: showMenu,
+          }
+        )}
+        tabIndex={0}
+        data-floating-menu-direction="bottom"
+        role="menu"
+        aria-labelledby="custom-actions-overflow-menu-trigger"
+        id="custom-actions-overflow-menu"
+      >
+        <ul
+          className={classNames("cds--overflow-menu-options__content", {
+            "cds--overflow-menu-options--lg": isTablet,
+          })}
+        >
+          {children}
+        </ul>
+        <span />
+      </div>
+    </div>
+  );
+};
+
+export default OrderCustomOverflowMenuComponent;

--- a/src/ui-components/overflow-menu.scss
+++ b/src/ui-components/overflow-menu.scss
@@ -1,0 +1,39 @@
+@use '@carbon/colors';
+@import '~@openmrs/esm-styleguide/src/vars';
+
+.container {
+  position: relative;
+  top: 0px;
+}
+
+.menu {
+  display: none;
+  top: 3.125rem;
+  min-width: initial;
+  left: auto;
+  right: 0;
+  background-color: $ui-01;
+  margin-right: 0.2rem;
+  box-shadow: 0 6px 6px rgb(0 0 0 / 30%);
+}
+
+.show {
+  display: block;
+}
+
+.overflowMenuButton {
+  width: auto;
+  height: auto;
+  padding: 0.875rem 1rem;
+  color: colors.$blue-60;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background-color: colors.$gray-10-hover;
+  }
+}
+
+.deceased {
+  color: colors.$blue-40;
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -12,5 +12,7 @@
   "transferred": "Transferred",
   "visitId": "Visit ID",
   "waitingTime": "Waiting time",
-  "worklist": "Worklist"
+  "worklist": "Worklist",
+  "rejectOrder": "Reject Order",
+  "pickLabRequest": "Pick Lab Request"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR is addressing the issue of adding adding an extension slot under lab order actions to make this more configurable so that implementations can add in whatever custom order actions that suit their needs 
## Screenshots
<img width="1223" alt="Screenshot 2024-01-03 at 4 56 20 PM" src="https://github.com/openmrs/openmrs-esm-laboratory/assets/46714226/533f76f0-8401-4be6-b316-673f5ccaaff8">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
