### PR TITLE
Remove select labelText for a clean ui

### DIFF
--- a/src/queue-list/lab-dialogs/add-to-worklist-dialog.component.tsx
+++ b/src/queue-list/lab-dialogs/add-to-worklist-dialog.component.tsx
@@ -236,7 +236,7 @@ const AddToWorklistDialog: React.FC<AddToWorklistDialogProps> = ({
                 <div style={{ width: "500px" }}>
                   <section className={styles.section}>
                     <Select
-                      labelText=" Specimen Type"
+                      labelText=""
                       id="speciment-types"
                       name="specimen-types"
                       value={specimenType}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
A minor ui fix that removes a misplaced labelText when selecting an order's specimen type

## Screenshots
Before: 
![Screenshot from 2024-01-05 11-01-19](https://github.com/openmrs/openmrs-esm-laboratory/assets/2161877/d8a1f79b-cc0c-4e04-bc63-b46b90ef21fd)

After:
![Screenshot from 2024-01-05 11-02-23](https://github.com/openmrs/openmrs-esm-laboratory/assets/2161877/ccefe05f-9e45-42d3-9c2c-facba0e4bfe0)


## Related Issue


## Other

