### PR TITLE
03-2725:Remove other tabs from the labs app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,26 @@ export const rejectOrderDialog = getAsyncLifecycle(
   options
 );
 
+export const worklistComponent = getAsyncLifecycle(
+  () => import("./queue-list/lab-tabs/work-list-tab.component"),
+  options
+);
+
+export const referredTestComponent = getAsyncLifecycle(
+  () => import("./queue-list/lab-tabs/referred-tab.component"),
+  options
+);
+
+export const reviewComponent = getAsyncLifecycle(
+  () => import("./queue-list/lab-tabs/review-tab.component"),
+  options
+);
+
+export const approvedComponent = getAsyncLifecycle(
+  () => import("./queue-list/lab-tabs/approved-tab.component"),
+  options
+);
+
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }

--- a/src/queue-list/lab-tabs/approved-tab.component.tsx
+++ b/src/queue-list/lab-tabs/approved-tab.component.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import CompletedList from "../../completed-list/completed-list.component";
+import styles from "./lab-tabs.scss";
+
+interface CompletedListComponentProps {
+  name: string;
+}
+
+const CompletedListComponent: React.FC<CompletedListComponentProps> = () => {
+  return (
+    <div>
+      <div className={styles.headerBtnContainer}></div>
+      <CompletedList fulfillerStatus={"COMPLETED"} />
+    </div>
+  );
+};
+
+export default CompletedListComponent;

--- a/src/queue-list/lab-tabs/referred-tab.component.tsx
+++ b/src/queue-list/lab-tabs/referred-tab.component.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { EmptyState } from "@openmrs/esm-patient-common-lib";
+import styles from "./lab-tabs.scss";
+
+interface ReferredTestsComponent {
+  name: string;
+}
+
+const ReferredTestsComponent: React.FC<ReferredTestsComponent> = () => {
+  return (
+    <div>
+      <div className={styles.headerBtnContainer}></div>
+      <EmptyState
+        displayText={"referred tests"}
+        headerTitle={"Referred tests"}
+      />
+    </div>
+  );
+};
+
+export default ReferredTestsComponent;

--- a/src/queue-list/lab-tabs/review-tab.component.tsx
+++ b/src/queue-list/lab-tabs/review-tab.component.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import ReviewList from "../../review-list/review-list.component";
+import styles from "./lab-tabs.scss";
+
+interface ReviewListComponentProps {
+  name: string;
+}
+
+const ReviewListComponent: React.FC<ReviewListComponentProps> = () => {
+  return (
+    <div>
+      <div className={styles.headerBtnContainer}></div>
+      <ReviewList fulfillerStatus={"IN_PROGRESS"} />
+    </div>
+  );
+};
+
+export default ReviewListComponent;

--- a/src/queue-list/lab-tabs/work-list-tab.component.tsx
+++ b/src/queue-list/lab-tabs/work-list-tab.component.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from "react";
+
+import { useTranslation } from "react-i18next";
+import styles from "./lab-tabs.scss";
+import WorkList from "../../work-list/work-list.component";
+
+interface WorkListComponentProps {
+  name: string;
+}
+
+const WorkListComponent: React.FC<WorkListComponentProps> = () => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <div className={styles.headerBtnContainer}></div>
+      <WorkList fulfillerStatus={"IN_PROGRESS"} />
+    </div>
+  );
+};
+
+export default WorkListComponent;

--- a/src/queue-list/laboratory-tabs.component.tsx
+++ b/src/queue-list/laboratory-tabs.component.tsx
@@ -4,10 +4,6 @@ import { useTranslation } from "react-i18next";
 import styles from "./laboratory-queue.scss";
 import LaboratoryPatientList from "./laboratory-patient-list.component";
 import { EmptyState } from "@openmrs/esm-patient-common-lib";
-import WorkList from "../work-list/work-list.component";
-import ReviewList from "../review-list/review-list.component";
-import CompletedList from "../completed-list/completed-list.component";
-
 enum TabTypes {
   STARRED,
   SYSTEM,
@@ -32,10 +28,6 @@ const LaboratoryQueueTabs: React.FC = () => {
             contained
           >
             <Tab>{t("testedOrders", "Tests ordered")}</Tab>
-            {/* <Tab>{t("worklist", "Worklist")}</Tab>
-            <Tab>{t("referredTests", "Referred tests")}</Tab>
-            <Tab>{t("reviewList", "Review")}</Tab>
-            <Tab>{t("approveList", "Approved")}</Tab> */}
           </TabList>
           <TabPanels>
             <TabPanel style={{ padding: 0 }}>
@@ -44,33 +36,6 @@ const LaboratoryQueueTabs: React.FC = () => {
                 <LaboratoryPatientList />
               </div>
             </TabPanel>
-            {/* <TabPanel style={{ padding: 0 }}>
-              <div>
-                <div className={styles.headerBtnContainer}></div>
-                <WorkList fulfillerStatus={"IN_PROGRESS"} />
-              </div>
-            </TabPanel>
-            <TabPanel style={{ padding: 0 }}>
-              <div>
-                <div className={styles.headerBtnContainer}></div>
-                <EmptyState
-                  displayText={"referred tests"}
-                  headerTitle={"Referred tests"}
-                />
-              </div>
-            </TabPanel>
-            <TabPanel style={{ padding: 0 }}>
-              <div>
-                <div className={styles.headerBtnContainer}></div>
-                <ReviewList fulfillerStatus={"IN_PROGRESS"} />
-              </div>
-            </TabPanel>
-            <TabPanel style={{ padding: 0 }}>
-              <div>
-                <div className={styles.headerBtnContainer}></div>
-                <CompletedList fulfillerStatus={"COMPLETED"} />
-              </div>
-            </TabPanel> */}
           </TabPanels>
         </Tabs>
       </section>

--- a/src/queue-list/laboratory-tabs.component.tsx
+++ b/src/queue-list/laboratory-tabs.component.tsx
@@ -32,10 +32,10 @@ const LaboratoryQueueTabs: React.FC = () => {
             contained
           >
             <Tab>{t("testedOrders", "Tests ordered")}</Tab>
-            <Tab>{t("worklist", "Worklist")}</Tab>
+            {/* <Tab>{t("worklist", "Worklist")}</Tab>
             <Tab>{t("referredTests", "Referred tests")}</Tab>
             <Tab>{t("reviewList", "Review")}</Tab>
-            <Tab>{t("approveList", "Approved")}</Tab>
+            <Tab>{t("approveList", "Approved")}</Tab> */}
           </TabList>
           <TabPanels>
             <TabPanel style={{ padding: 0 }}>
@@ -44,7 +44,7 @@ const LaboratoryQueueTabs: React.FC = () => {
                 <LaboratoryPatientList />
               </div>
             </TabPanel>
-            <TabPanel style={{ padding: 0 }}>
+            {/* <TabPanel style={{ padding: 0 }}>
               <div>
                 <div className={styles.headerBtnContainer}></div>
                 <WorkList fulfillerStatus={"IN_PROGRESS"} />
@@ -70,7 +70,7 @@ const LaboratoryQueueTabs: React.FC = () => {
                 <div className={styles.headerBtnContainer}></div>
                 <CompletedList fulfillerStatus={"COMPLETED"} />
               </div>
-            </TabPanel>
+            </TabPanel> */}
           </TabPanels>
         </Tabs>
       </section>

--- a/src/queue-list/my.component.tsx
+++ b/src/queue-list/my.component.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+// Define the props interface for the component
+interface MyComponentProps {
+  name: string;
+}
+
+// Define the functional component using TypeScript
+const MyComponent: React.FC<MyComponentProps> = ({ name }) => {
+  return (
+    <div>
+      <h1>Hello, {name}!</h1>
+      <p>This is a sample TypeScript React component.</p>
+    </div>
+  );
+};
+
+export default MyComponent;

--- a/src/routes.json
+++ b/src/routes.json
@@ -67,6 +67,42 @@
     {
       "name" : "reject-order-dialog",
       "component": "rejectOrderDialog"
+    },
+    {
+      "name": "worklist-panel-component",
+      "slot": "lab-panels-slot",
+      "component": "worklistComponent",
+      "meta": {
+        "name": "worklistPanelSlot",
+        "title": "Worklist"
+      }
+    },
+    {
+      "name": "referred-panel-component",
+      "slot": "lab-panels-slot",
+      "component": "referredTestComponent",
+      "meta": {
+        "name": "referredPanleSlot",
+        "title": "Referred tests"
+      }
+    },
+    {
+      "name": "review-panel-component",
+      "slot": "lab-panels-slot",
+      "component": "reviewComponent",
+      "meta": {
+        "name": "reviewPanelSlot",
+        "title": "Review"
+      }
+    },
+    {
+      "name": "approved-panel-component",
+      "slot": "lab-panels-slot",
+      "component": "approvedComponent",
+      "meta": {
+        "name": "approvedPanelSlot",
+        "title": "Approved"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
We would like to only retain the Tests ordered tab visible in the app UI .
Other tabs can be added via extensions according  to implementation custom needs 
## Screenshots
<img width="1089" alt="Screenshot 2024-01-10 at 12 32 17 PM" src="https://github.com/openmrs/openmrs-esm-laboratory/assets/46714226/fb56a904-157e-47ef-ba7e-fd9dd597c3bb">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-2725
## Other
<!-- Anything not covered above -->
