### PR TITLE
tile:adding summary tiles as extesnions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ For more information, please refer to the
 
 <img src="https://raw.githubusercontent.com/openmrs/openmrs-esm-laboratory/main/assets/screenshots/labs_enter_results.png" />
 
+### Adding or removing summary tiles
+Implementers can add or remove summary tiles via extension configuration in the [routes.js](https://github.com/openmrs/openmrs-esm-laboratory/blob/main/src/routes.json) json file 
+
 # Getting Started
 
 ```sh

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,26 @@ export const rejectOrderButton = getAsyncLifecycle(
   options
 );
 
+export const worklisTileComponent = getAsyncLifecycle(
+  () => import("./lab-tiles/worklist-tile.component"),
+  options
+);
+
+export const referredTileComponent = getAsyncLifecycle(
+  () => import("./lab-tiles/referred-tile.component"),
+  options
+);
+
+export const completedTileSlot = getAsyncLifecycle(
+  () => import("./lab-tiles/completed-tile.component"),
+  options
+);
+
+export const testOrderedTileComponent = getAsyncLifecycle(
+  () => import("./lab-tiles/tests-ordered-tile.component"),
+  options
+);
+
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export const rejectOrderButton = getAsyncLifecycle(
   options
 );
 
-export const worklisTileComponent = getAsyncLifecycle(
+export const worklistTileComponent = getAsyncLifecycle(
   () => import("./lab-tiles/worklist-tile.component"),
   options
 );
@@ -128,7 +128,7 @@ export const referredTileComponent = getAsyncLifecycle(
   options
 );
 
-export const completedTileSlot = getAsyncLifecycle(
+export const completedTileComponent = getAsyncLifecycle(
   () => import("./lab-tiles/completed-tile.component"),
   options
 );

--- a/src/lab-tiles/completed-tile.component.tsx
+++ b/src/lab-tiles/completed-tile.component.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import CompletedList from "../completed-list/completed-list.component";
+import styles from "../queue-list/laboratory-queue.scss";
+import { useTranslation } from "react-i18next";
+import SummaryTile from "../summary-tiles/summary-tile.component";
+import { useLabTestsStats } from "../summary-tiles/laboratory-summary.resource";
+
+const ReferredTileComponent = () => {
+  const { t } = useTranslation();
+
+  const { count: completedCount } = useLabTestsStats("COMPLETED");
+
+  return (
+    <SummaryTile
+      label={t("completed", "Completed")}
+      value={completedCount}
+      headerLabel={t("results", "Results")}
+    />
+  );
+};
+
+export default ReferredTileComponent;

--- a/src/lab-tiles/referred-tile.component.tsx
+++ b/src/lab-tiles/referred-tile.component.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import CompletedList from "../completed-list/completed-list.component";
+import styles from "../queue-list/laboratory-queue.scss";
+import { useTranslation } from "react-i18next";
+import SummaryTile from "../summary-tiles/summary-tile.component";
+
+const ReferredTileComponent = () => {
+  const { t } = useTranslation();
+
+  return (
+    <SummaryTile
+      label={t("transferred", "Transferred")}
+      value={0}
+      headerLabel={t("referredTests", "Ex-Referred tests")}
+    />
+  );
+};
+
+export default ReferredTileComponent;

--- a/src/lab-tiles/tests-ordered-tile.component.tsx
+++ b/src/lab-tiles/tests-ordered-tile.component.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import CompletedList from "../completed-list/completed-list.component";
+import styles from "../queue-list/laboratory-queue.scss";
+import { useTranslation } from "react-i18next";
+import SummaryTile from "../summary-tiles/summary-tile.component";
+import { useLabTestsStats } from "../summary-tiles/laboratory-summary.resource";
+
+const ReferredTileComponent = () => {
+  const { t } = useTranslation();
+
+  const { count: testOrderedCount } = useLabTestsStats("");
+
+  return (
+    <SummaryTile
+      label={t("orders", "Orders")}
+      value={testOrderedCount}
+      headerLabel={t("testsOrdered", "Tests ordered")}
+    />
+  );
+};
+
+export default ReferredTileComponent;

--- a/src/lab-tiles/worklist-tile.component.tsx
+++ b/src/lab-tiles/worklist-tile.component.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import CompletedList from "../completed-list/completed-list.component";
+import styles from "../queue-list/laboratory-queue.scss";
+import { useTranslation } from "react-i18next";
+import SummaryTile from "../summary-tiles/summary-tile.component";
+import { useLabTestsStats } from "../summary-tiles/laboratory-summary.resource";
+
+const WorklistTileComponent = () => {
+  const { t } = useTranslation();
+
+  const { count: worklistCount } = useLabTestsStats("IN_PROGRESS");
+
+  return (
+    <SummaryTile
+      label={t("inProgress", "In progress")}
+      value={worklistCount}
+      headerLabel={t("worklist", "Ex-Worklist")}
+    />
+  );
+};
+
+export default WorklistTileComponent;

--- a/src/routes.json
+++ b/src/routes.json
@@ -105,6 +105,43 @@
       }
     },
     {
+      "name": "worklist-tile-component",
+      "slot": "lab-tiles-slot",
+      "component": "worklisTileComponent",
+      "meta": {
+        "name": "worklisTileSlot",
+        "title": "Ex-Worklist"
+      }
+    },
+    {
+      "name": "referred-tile-component",
+      "slot": "lab-tiles-slot",
+      "component": "referredTileComponent",
+      "meta": {
+        "name": "referredTileSlot",
+        "title": "Ex-Referred tests"
+      }
+    },
+    {
+      "name": "completed-tile-component",
+      "slot": "lab-tiles-slot",
+      "component": "completedTileComponent",
+      "meta": {
+        "name": "completedTileSlot",
+        "title": "Ex-Completed tests"
+      }
+    },
+
+    {
+      "name": "tests-ordered-tile-component",
+      "slot": "lab-tiles-slot",
+      "component": "testOrderedTileComponent",
+      "meta": {
+        "name": "testsOrderedTileSlot",
+        "title": "Ex-Ordered tests"
+      }
+    },
+    {
       "name": "pick-lab-request-button",
       "component": "pickLabRequestButton",
       "slot": "order-actions-slot"

--- a/src/routes.json
+++ b/src/routes.json
@@ -105,12 +105,30 @@
       }
     },
     {
+      "name": "tests-ordered-tile-component",
+      "slot": "lab-tiles-slot",
+      "component": "testOrderedTileComponent",
+      "meta": {
+        "name": "testsOrderedTileSlot",
+        "title": "Ordered tests"
+      }
+    },
+    {
+      "name": "completed-tile-component",
+      "slot": "lab-tiles-slot",
+      "component": "completedTileComponent",
+      "meta": {
+        "name": "completedTileSlot",
+        "title": "Completed"
+      }
+    },
+    {
       "name": "worklist-tile-component",
       "slot": "lab-tiles-slot",
-      "component": "worklisTileComponent",
+      "component": "worklistTileComponent",
       "meta": {
         "name": "worklisTileSlot",
-        "title": "Ex-Worklist"
+        "title": "Worklist"
       }
     },
     {
@@ -122,25 +140,7 @@
         "title": "Ex-Referred tests"
       }
     },
-    {
-      "name": "completed-tile-component",
-      "slot": "lab-tiles-slot",
-      "component": "completedTileComponent",
-      "meta": {
-        "name": "completedTileSlot",
-        "title": "Ex-Completed tests"
-      }
-    },
-
-    {
-      "name": "tests-ordered-tile-component",
-      "slot": "lab-tiles-slot",
-      "component": "testOrderedTileComponent",
-      "meta": {
-        "name": "testsOrderedTileSlot",
-        "title": "Ex-Ordered tests"
-      }
-    },
+   
     {
       "name": "pick-lab-request-button",
       "component": "pickLabRequestButton",

--- a/src/routes.json
+++ b/src/routes.json
@@ -137,7 +137,7 @@
       "component": "referredTileComponent",
       "meta": {
         "name": "referredTileSlot",
-        "title": "Ex-Referred tests"
+        "title": "Referred tests"
       }
     },
    

--- a/src/summary-tiles/laboratory-summary-tiles.component.tsx
+++ b/src/summary-tiles/laboratory-summary-tiles.component.tsx
@@ -3,13 +3,30 @@ import { useTranslation } from "react-i18next";
 import { useLabTestsStats, useMetrics } from "./laboratory-summary.resource";
 import SummaryTile from "./summary-tile.component";
 import styles from "./laboratory-summary-tiles.scss";
-import { useSession } from "@openmrs/esm-framework";
+import {
+  AssignedExtension,
+  Extension,
+  ExtensionSlot,
+  useConnectedExtensions,
+  useSession,
+} from "@openmrs/esm-framework";
 import { usePatientQueuesList } from "../queue-list/laboratory-patient-list.resource";
 
 const LaboratorySummaryTiles: React.FC = () => {
   const { t } = useTranslation();
 
   const session = useSession();
+
+  const labTileSlot = "lab-tiles-slot";
+
+  const tilesExtensions = useConnectedExtensions(
+    labTileSlot
+  ) as AssignedExtension[];
+
+  // eslint-disable-next-line no-console
+  console.log(tilesExtensions);
+
+  // console.log{tilesExtensions};
 
   // get tests ordered
   const { count: testOrderedCount } = useLabTestsStats("");
@@ -23,30 +40,33 @@ const LaboratorySummaryTiles: React.FC = () => {
   const { count: completedCount } = useLabTestsStats("COMPLETED");
 
   return (
-    <>
-      <div className={styles.cardContainer}>
-        <SummaryTile
-          label={t("orders", "Orders")}
-          value={testOrderedCount}
-          headerLabel={t("testsOrdered", "Tests ordered")}
-        />
-        <SummaryTile
-          label={t("inProgress", "In progress")}
-          value={worklistCount}
-          headerLabel={t("worklist", "Worklist")}
-        />
-        <SummaryTile
-          label={t("transferred", "Transferred")}
-          value={0}
-          headerLabel={t("referredTests", "Referred tests")}
-        />
-        <SummaryTile
-          label={t("completed", "Completed")}
-          value={completedCount}
-          headerLabel={t("results", "Results")}
-        />
-      </div>
-    </>
+    <div className={styles.cardContainer}>
+      <SummaryTile
+        label={t("orders", "Orders")}
+        value={testOrderedCount}
+        headerLabel={t("testsOrdered", "Tests ordered")}
+      />
+      <SummaryTile
+        label={t("inProgress", "In progress")}
+        value={worklistCount}
+        headerLabel={t("worklist", "Worklist")}
+      />
+      <SummaryTile
+        label={t("transferred", "Transferred")}
+        value={0}
+        headerLabel={t("referredTests", "Referred tests")}
+      />
+      <SummaryTile
+        label={t("completed", "Completed")}
+        value={completedCount}
+        headerLabel={t("results", "Results")}
+      />
+
+      <ExtensionSlot name={labTileSlot}>
+        {" "}
+        <Extension />
+      </ExtensionSlot>
+    </div>
   );
 };
 

--- a/src/summary-tiles/laboratory-summary-tiles.component.tsx
+++ b/src/summary-tiles/laboratory-summary-tiles.component.tsx
@@ -8,7 +8,10 @@ import {
   useSession,
   attach,
   detachAll,
+  Extension,
 } from "@openmrs/esm-framework";
+import { ComponentContext } from "@openmrs/esm-framework/src/internal";
+import SummaryTile from "./summary-tile.component";
 
 const LaboratorySummaryTiles: React.FC = () => {
   const { t } = useTranslation();
@@ -21,42 +24,29 @@ const LaboratorySummaryTiles: React.FC = () => {
     labTileSlot
   ) as AssignedExtension[];
 
-  const [derivedSlots, setDerivedSlots] = useState<
-    { slot: string; extension: string }[]
-  >([]);
-
-  const extraTiles = useMemo(() => {
-    const filteredExtensions = tilesExtensions.filter(
-      (extension) => Object.keys(extension.meta).length > 0
-    );
-    const derivedSlotsBuffer = [];
-    return filteredExtensions.map((extension, index) => {
-      const slotName = `${labTileSlot}-${index}`;
-      derivedSlotsBuffer.push({
-        slot: slotName,
-        extension: extension.name,
-      });
-      if (filteredExtensions.length === index + 1) {
-        setDerivedSlots(derivedSlotsBuffer);
-      }
-
-      return <ExtensionSlot name={slotName} />;
-    });
-  }, [tilesExtensions]);
-
-  useEffect(() => {
-    derivedSlots.forEach(({ slot, extension }) => {
-      attach(slot, extension);
-    });
-
-    return () => {
-      derivedSlots.forEach(({ slot }) => {
-        detachAll(slot);
-      });
-    };
-  }, [derivedSlots]);
-
-  return <div className={styles.cardContainer}>{extraTiles}</div>;
+  return (
+    <div className={styles.cardContainer}>
+      {tilesExtensions
+        .filter((extension) => Object.keys(extension.meta).length > 0)
+        .map((extension, index) => {
+          return (
+            <ComponentContext.Provider
+              key={extension.id}
+              value={{
+                moduleName: extension.moduleName,
+                extension: {
+                  extensionId: extension.id,
+                  extensionSlotName: labTileSlot,
+                  extensionSlotModuleName: extension.moduleName,
+                },
+              }}
+            >
+              <Extension />
+            </ComponentContext.Provider>
+          );
+        })}
+    </div>
+  );
 };
 
 export default LaboratorySummaryTiles;

--- a/src/summary-tiles/laboratory-summary-tiles.scss
+++ b/src/summary-tiles/laboratory-summary-tiles.scss
@@ -5,7 +5,7 @@
 .cardContainer {
   background-color: $ui-02 ;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   padding: 0 spacing.$spacing-05 spacing.$spacing-10 spacing.$spacing-03;
   flex-flow: row wrap;
   margin-top: - spacing.$spacing-03;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The PR is also addressing the similar  issue of the lab-tiles-slot which will not be visible in the implementer tools UI when used below
in the value for ComponentContext.Provider as the UI viewer depends on the div that cannot be added because of how the Carbon components work. Implementers can add more tab extensions to this slot via the routes.js file configuration.


## Screenshots
<img width="1258" alt="Screenshot 2024-01-24 at 3 44 43 PM" src="https://github.com/openmrs/openmrs-esm-laboratory/assets/46714226/3de680e2-e646-4a8a-8b9e-b445fb086bde">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
