### PR TITLE
revise-panels:refining the rendering of extensions in the lab-panels-slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ For more information, please refer to the
 
 ### Adding Results
 
+### Adding tab panels
+Implementers can add or remove laboratory tab panels via extension configuration in the [routes.js](https://github.com/openmrs/openmrs-esm-laboratory/blob/main/src/routes.json) json file 
+
+
 <img src="https://raw.githubusercontent.com/openmrs/openmrs-esm-laboratory/main/assets/screenshots/labs_enter_results.png" />
 
 # Getting Started

--- a/src/queue-list/laboratory-tabs.component.tsx
+++ b/src/queue-list/laboratory-tabs.component.tsx
@@ -24,10 +24,6 @@ enum TabTypes {
   ALL,
 }
 
-// The lab-panels-slot will not be visible in the implementer tools UI when used below
-// in the value for ComponentContext.Provider as the UI viewer depends on the div that
-// cannot be added because of how the Carbon components work. Implementers can add more
-// tab extensions to this slot via the routes.js file configuration.
 const labPanelSlot = "lab-panels-slot";
 
 const LaboratoryQueueTabs: React.FC = () => {

--- a/src/queue-list/laboratory-tabs.component.tsx
+++ b/src/queue-list/laboratory-tabs.component.tsx
@@ -27,7 +27,7 @@ enum TabTypes {
 // The lab-panels-slot will not be visible in the implementer tools UI when used below
 // in the value for ComponentContext.Provider as the UI viewer depends on the div that
 // cannot be added because of how the Carbon components work. Implementers can add more
-// tab extensions to this slot via the routes.js file configuration
+// tab extensions to this slot via the routes.js file configuration.
 const labPanelSlot = "lab-panels-slot";
 
 const LaboratoryQueueTabs: React.FC = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4022,27 +4022,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-api@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-api@npm:5.3.2"
+"@openmrs/esm-api@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-api@npm:5.3.3-pre.1429"
   dependencies:
     "@types/fhir": 0.0.31
     lodash-es: ^4.17.21
   peerDependencies:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-offline": 5.x
-  checksum: ba881c7056af96d38601724bc9792dcdbd65b1e9fa9b9c66dc979bcb16de2675bc2aa81487e750464d105533933420b387ba19036f0b56dd129de222ce4a2aba
+  checksum: 3359152206cd37fb5cd985774ebfc00d225c6e31f4a8269753dba2fdf1dbf04df200d6b54ee06faa59f11956ab3479af735c9e9a2645fd34d3f8e3f9947ad333
   languageName: node
   linkType: hard
 
-"@openmrs/esm-app-shell@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-app-shell@npm:5.3.2"
+"@openmrs/esm-app-shell@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-app-shell@npm:5.3.3-pre.1429"
   dependencies:
     "@carbon/react": ~1.37.0
-    "@openmrs/esm-framework": 5.3.2
-    "@openmrs/esm-styleguide": 5.3.2
+    "@openmrs/esm-framework": 5.3.3-pre.1429
+    "@openmrs/esm-styleguide": 5.3.3-pre.1429
     dayjs: ^1.10.4
     dexie: ^3.0.3
     html-webpack-plugin: ^5.5.0
@@ -4056,7 +4057,7 @@ __metadata:
     react-router-dom: ^6.3.0
     rxjs: ^6.5.3
     semver: ^7.3.4
-    single-spa: ^5.9.2
+    single-spa: ^6.0.0
     swc-loader: ^0.2.3
     swr: ^2.2.2
     systemjs: ^6.8.3
@@ -4067,55 +4068,44 @@ __metadata:
     workbox-strategies: ^6.1.5
     workbox-webpack-plugin: ^6.1.5
     workbox-window: ^6.1.5
-  checksum: 66450d1618e5f75dcb33c477671c969eb3c0913fd7495e0ab6e588b6e570b4ab62366d25257d686f91a17d88f120a0fb0d9e9c1d59391f8e3812831d6a26505d
+  checksum: be55e890adc409b152eb9ab8d002200688d32f6235fcace227e6a956d8a366cff9cbfcb4e680b081b4328be8b2dd748d37b2b89c2fa184f3bf8c570285fee94e
   languageName: node
   linkType: hard
 
-"@openmrs/esm-breadcrumbs@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-breadcrumbs@npm:5.3.2"
-  dependencies:
-    path-to-regexp: 6.1.0
-  peerDependencies:
-    "@openmrs/esm-state": 5.x
-  checksum: b2f7a71b7d1d72679232ffe2f511ff3c8311eb00a410539a586828ad857774cbd71e51e3f3f0ef5f4243282dbe844de457370de052e19631bbd44327bf5d765b
-  languageName: node
-  linkType: hard
-
-"@openmrs/esm-config@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-config@npm:5.3.2"
+"@openmrs/esm-config@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-config@npm:5.3.3-pre.1429"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 3fbbb302383847d2cf86c96318fd1f598d5b8c1f4d22818f8839752dd6f8760cc2e7737a403f9c03ef6587bbb9af95b370fbff3dcf863dba8cd615e649c2197c
+  checksum: 19d0247271f427a68ec4a8850c1cb99d1259d0a3efeb957774d8c81eafb4b8c6e365c3fe2593b188a347c0743d01aea3bec1a9d68e1723a6b84d14c43ba09127
   languageName: node
   linkType: hard
 
-"@openmrs/esm-dynamic-loading@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.2"
+"@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.3.3-pre.1429"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: ecb310eb8bcbc25a0108a6ce0b003f128a407b55e2864ad79b4a0137be55318c5adaf292060d18762b42449523eabbb37343f60d4898a4d2b9e86b3362536c7b
+  checksum: b749a65b089afe95068ef290f828fa0413036cba932a5c08e1cbafbd2351b11f57e6b0870c616ec41446ee80fd6953dea84e081791afa2f74865c12957e4a2a7
   languageName: node
   linkType: hard
 
-"@openmrs/esm-error-handling@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-error-handling@npm:5.3.2"
+"@openmrs/esm-error-handling@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-error-handling@npm:5.3.3-pre.1429"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: 3e723fc58c9791a96da179bb678048f32393dd8629e28201ae45287d61794ee0826b86a8183868b152a5f109110c972bd2beb0839bc58a9addc06008a8201569
+  checksum: 562edd1cfaf07e6b78153476fd50f88efaaa2039281132d06237c0ab0f80f4d378ca4c27af6c9da6085e46b1573314a29540ccd0eb5321d3a3cf4fa3211ac346
   languageName: node
   linkType: hard
 
-"@openmrs/esm-extensions@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-extensions@npm:5.3.2"
+"@openmrs/esm-extensions@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-extensions@npm:5.3.3-pre.1429"
   dependencies:
     lodash-es: ^4.17.21
   peerDependencies:
@@ -4124,7 +4114,7 @@ __metadata:
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 4fe098b0e1dc9f9402f4683cddaa391b0cf6fda77f2d951fad3edad9022583e49d079bc956b2c37fbe231547661ff22c09a82b4fc92a831debf8f0d3faf37e02
+  checksum: 168d2a79d814b6f421503e58b906cecf6b0afb52f05132f8a744affa5108108f6588b2f1c7df70970375b6c454345f6698fab62cff8ac29b8207bc5dfeab3f7e
   languageName: node
   linkType: hard
 
@@ -4143,36 +4133,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-feature-flags@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-feature-flags@npm:5.3.2"
+"@openmrs/esm-feature-flags@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-feature-flags@npm:5.3.3-pre.1429"
   dependencies:
     ramda: ^0.26.1
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
     single-spa: 5.x
-  checksum: 8fbda6e1102609d1eaea37b537cf6735492404a2dbac570e262016b167eb5a6ba05ca243feacb1b40c303e54889c63fd7bcf0b7aa41da55ad43faf36650b685f
+  checksum: 64fc2ee2354310f6eaf248b80f35ad3a68cbbed79b761afe4b00a56388ce48696b8a88a814a8cb36efda68007184e721d7a4fb0e2f58fea5205de97075a4fe78
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:5.3.2, @openmrs/esm-framework@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-framework@npm:5.3.2"
+"@openmrs/esm-framework@npm:5.3.3-pre.1429, @openmrs/esm-framework@npm:next":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-framework@npm:5.3.3-pre.1429"
   dependencies:
-    "@openmrs/esm-api": 5.3.2
-    "@openmrs/esm-breadcrumbs": 5.3.2
-    "@openmrs/esm-config": 5.3.2
-    "@openmrs/esm-dynamic-loading": 5.3.2
-    "@openmrs/esm-error-handling": 5.3.2
-    "@openmrs/esm-extensions": 5.3.2
-    "@openmrs/esm-feature-flags": 5.3.2
-    "@openmrs/esm-globals": 5.3.2
-    "@openmrs/esm-offline": 5.3.2
-    "@openmrs/esm-react-utils": 5.3.2
-    "@openmrs/esm-state": 5.3.2
-    "@openmrs/esm-styleguide": 5.3.2
-    "@openmrs/esm-utils": 5.3.2
+    "@openmrs/esm-api": 5.3.3-pre.1429
+    "@openmrs/esm-config": 5.3.3-pre.1429
+    "@openmrs/esm-dynamic-loading": 5.3.3-pre.1429
+    "@openmrs/esm-error-handling": 5.3.3-pre.1429
+    "@openmrs/esm-extensions": 5.3.3-pre.1429
+    "@openmrs/esm-feature-flags": 5.3.3-pre.1429
+    "@openmrs/esm-globals": 5.3.3-pre.1429
+    "@openmrs/esm-navigation": 5.3.3-pre.1429
+    "@openmrs/esm-offline": 5.3.3-pre.1429
+    "@openmrs/esm-react-utils": 5.3.3-pre.1429
+    "@openmrs/esm-routes": 5.3.3-pre.1429
+    "@openmrs/esm-state": 5.3.3-pre.1429
+    "@openmrs/esm-styleguide": 5.3.3-pre.1429
+    "@openmrs/esm-utils": 5.3.3-pre.1429
     dayjs: ^1.10.7
   peerDependencies:
     dayjs: 1.x
@@ -4183,16 +4174,16 @@ __metadata:
     rxjs: 6.x
     single-spa: 5.x
     swr: 2.x
-  checksum: a23153cc64959054570c7a9e2a98a9219fd794f70ed4f08cc0696a30ba5bdbb38a372945d407669cf6a34cf293679e5f247c3c86ac7c069dc81bfd6df7759335
+  checksum: 9bb6f2605dd418cb4a0831d4998f995b58ad41498bcb87aaf2cc9a569fb56e83feb4415740082918e1ffe1ef3d4d9646c7fbe84464e6168b8a7f8ab50a83fc84
   languageName: node
   linkType: hard
 
-"@openmrs/esm-globals@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-globals@npm:5.3.2"
+"@openmrs/esm-globals@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-globals@npm:5.3.3-pre.1429"
   peerDependencies:
     single-spa: 5.x
-  checksum: 1fe5eceb04f2b50c20f4e0f408ddf9b645b2ec4f3971815a49875ce3555438766a4e3b9b2a86b922627f18d50baf07407aa6a47f6b89673364b2e2b96c3ac9a6
+  checksum: 00f1e80081f1aa179fc03aa86eecf319403f34e4e3560c09d6dfb3a4f136117bf6499ce9907eb7a43663f16a420e5364c21a0b657cef816f4a29b07698337a40
   languageName: node
   linkType: hard
 
@@ -4204,7 +4195,7 @@ __metadata:
     "@hookform/resolvers": ^3.3.4
     "@ohri/openmrs-esm-ohri-commons-lib": next
     "@openmrs/esm-extensions": next
-    "@openmrs/esm-framework": ^5.3.2
+    "@openmrs/esm-framework": next
     "@openmrs/esm-patient-common-lib": next
     "@openmrs/esm-react-utils": next
     "@openmrs/esm-styleguide": next
@@ -4238,7 +4229,7 @@ __metadata:
     jest-environment-jsdom: ^28.1.3
     lerna: ^5.6.1
     lodash-es: ^4.17.21
-    openmrs: ^5.3.2
+    openmrs: next
     plotly.js: ^2.24.3
     prettier: ^2.8.8
     pretty-quick: ^3.1.3
@@ -4270,9 +4261,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-offline@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-offline@npm:5.3.2"
+"@openmrs/esm-navigation@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-navigation@npm:5.3.3-pre.1429"
+  dependencies:
+    path-to-regexp: 6.1.0
+  peerDependencies:
+    "@openmrs/esm-state": 5.x
+  checksum: ee718b9237d500d6d2845bbbf5e91463d00d777ed787580c22eddddb050ab596b5d11ba42904a05debb62686b0106bb5e2864e488a9c45286643d40c5e2c1367
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-offline@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-offline@npm:5.3.3-pre.1429"
   dependencies:
     dexie: ^3.0.3
     lodash-es: ^4.17.21
@@ -4284,7 +4286,7 @@ __metadata:
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
-  checksum: fd54a8d342b6b073b6e0610ea13e3ccc4477a97f99b03a4dd0df0a8acbda75eeac94a40818f702d90619610ea8e63e806129032e23799d3a64c31dbf560ac0f2
+  checksum: c38f95f75160247e176d7605e931c436f0c2eb888740701ccac2af5f471096d739effea0b1b57aeab007f8658ddc3027b54fc473d58174c09570518e89501a79
   languageName: node
   linkType: hard
 
@@ -4303,18 +4305,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-react-utils@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-react-utils@npm:5.3.2"
+"@openmrs/esm-react-utils@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-react-utils@npm:5.3.3-pre.1429"
   dependencies:
     lodash-es: ^4.17.21
-    single-spa-react: ~5.0.0
+    single-spa-react: ^6.0.0
   peerDependencies:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-extensions": 5.x
     "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-navigation": 5.x
     dayjs: 1.x
     i18next: 19.x
     react: 18.x
@@ -4322,7 +4325,7 @@ __metadata:
     react-i18next: 11.x
     rxjs: 6.x
     swr: 2.x
-  checksum: 7e94645a3d0e80148fa59de1a503922bae65a1dd21b9902a0d0dab42fa241b81b6cefa0b5edcb1d38328b41d1a856f4a61c9e012eee1d0b3b89c12ba01e90ca4
+  checksum: 98c4e235885735eacb9a2e642120521353cb17aa7921926d69c588d1db0bde8e550295b6be58cdb7b6d6e9972679fd325dc1eba0f49f111bb940d151d28ffd96
   languageName: node
   linkType: hard
 
@@ -4348,20 +4351,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-state@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-state@npm:5.3.2"
+"@openmrs/esm-routes@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-routes@npm:5.3.3-pre.1429"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-utils": 5.x
+  checksum: c89f6a58bcd777857e44128ffed5473ca22e0ad9c36cc5316e8c5a5c8f6ab370d0ca5b0bb3b8583a6b2127ae908e44fee979f1f56b3844e7eecc186c3379b75c
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-state@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-state@npm:5.3.3-pre.1429"
   dependencies:
     zustand: ^4.3.6
   peerDependencies:
     "@openmrs/esm-globals": 5.x
-  checksum: a72e1998f898732da757122699eed4e35eea1e1872fceb98846c0c98ac1c350c5459a94aff1cbf7339e81adf64cfc79e088dabba663ac7653ed95700ca72504f
+  checksum: c954ab3665d599525570f93c0f509e552e25393403e14241790c87647311fd0b5fd0ab4f06b7b3a5da3f405abc0ba640eda1ea325c1da2e4e0ec18ad78b0e04b
   languageName: node
   linkType: hard
 
-"@openmrs/esm-styleguide@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-styleguide@npm:5.3.2"
+"@openmrs/esm-styleguide@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-styleguide@npm:5.3.3-pre.1429"
   dependencies:
     "@carbon/charts": ^1.12.0
     "@carbon/react": ~1.37.0
@@ -4380,7 +4393,7 @@ __metadata:
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
-  checksum: c022f9ce9d4c80014a92d9660753ffdcf9d7cea8ba9cae60bfdad26716ebc35e901a6606376107aed4a1e9fcdb48f07077b849ab9e87dc4200b289caf9237b9a
+  checksum: ffea8a0c6189d598c2e1882f23b05e7ebddf2d8b877cf9277c93401815f4f4ae4f7d39e9eb946d5150747b06b5218cbce61ab527eb3ec604fee4391cfefc1edb
   languageName: node
   linkType: hard
 
@@ -4407,16 +4420,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-utils@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/esm-utils@npm:5.3.2"
+"@openmrs/esm-utils@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/esm-utils@npm:5.3.3-pre.1429"
   dependencies:
     semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
     rxjs: 6.x
-  checksum: 91e4c4dbb170f8a13e9d036b93e67b781962aa34f06ed996e547319fe6d982277508c42c7e1efa4c5784ed93da4bf95e953c46a48078a2135e171fef9d720fae
+  checksum: b60d219f1fc8ba7df17ed5983202eeb461438d2e9201251c6632cf3f483f7a34135610355fdad7a8c1e7fb507e591f4ac6ec6cf702d59b8c586ef1e06e6db38b
   languageName: node
   linkType: hard
 
@@ -4449,9 +4462,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/webpack-config@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@openmrs/webpack-config@npm:5.3.2"
+"@openmrs/webpack-config@npm:5.3.3-pre.1429":
+  version: 5.3.3-pre.1429
+  resolution: "@openmrs/webpack-config@npm:5.3.3-pre.1429"
   dependencies:
     "@swc/core": ^1.3.58
     clean-webpack-plugin: ^4.0.0
@@ -4468,7 +4481,7 @@ __metadata:
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
     webpack: 5.x
-  checksum: eac02d7082fa4d08cc6bbbdd722d49576b074e15750401358a6c8c4c7bb38af68944ed60283a49b32f5315ada67724f1515c1706814396fa7c3cc89045a195ba
+  checksum: 371a55d46a2ba4f0ee56aeffe28f67194385afb59e5d0bc7ebd158999dc3206978ea109a0fa86558cb147ecaa8b48156205bfef22578e4cb809fb835bda8571b
   languageName: node
   linkType: hard
 
@@ -8262,7 +8275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -16628,6 +16641,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-watch@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "node-watch@npm:0.7.4"
+  checksum: effca2aa3575afdc8caae2a422d5738ecf8322962f051574c5dd3c1a399b4bf188c3ad3cb32890fc5e530604f0f037bc0160ec94b37f8d3ae4b76006a98f9df3
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -17213,18 +17233,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openmrs@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "openmrs@npm:5.3.2"
+"openmrs@npm:next":
+  version: 5.3.3-pre.1429
+  resolution: "openmrs@npm:5.3.3-pre.1429"
   dependencies:
     "@carbon/icons-react": 11.26.0
-    "@openmrs/esm-app-shell": 5.3.2
-    "@openmrs/webpack-config": 5.3.2
+    "@openmrs/esm-app-shell": 5.3.3-pre.1429
+    "@openmrs/webpack-config": 5.3.3-pre.1429
     "@pnpm/npm-conf": ^2.1.0
     "@swc/core": ^1.3.58
     autoprefixer: ^10.4.2
     axios: ^0.21.1
     browserslist-config-openmrs: ^1.0.1
+    chalk: ^4.1.2
     copy-webpack-plugin: ^11.0.0
     cssnano: ^5.0.16
     ejs: ^3.1.8
@@ -17232,6 +17253,7 @@ __metadata:
     html-webpack-plugin: ^5.5.0
     inquirer: ^7.3.3
     mini-css-extract-plugin: ^2.4.5
+    node-watch: ^0.7.4
     npm-registry-fetch: ^14.0.3
     pacote: ^15.0.0
     postcss: ^8.4.6
@@ -17248,7 +17270,7 @@ __metadata:
     yargs: ^17.6.2
   bin:
     openmrs: ./dist/cli.js
-  checksum: f44ce33a108a7ad4113cf705006a0f4886ecb5c40046d61cfc25422bdb78027575a13d7b1d41588ea5e5d82bfca9828dc1c96130f4e0f0536d9f86d3ee8a9b4a
+  checksum: 1eb8f573ce4a02e56b609dd4431d9d9ac24b26cbd101e7c97b806719c7bdadf3a649ff090e766b8f69dad5c05c84c5bf010c9ff1b7cada6606a7b57672da5c0a
   languageName: node
   linkType: hard
 
@@ -20267,6 +20289,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"single-spa-react@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "single-spa-react@npm:6.0.1"
+  dependencies:
+    browserslist-config-single-spa: ^1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: "*"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: aefe69502735a5a4062a0539d61e2b1e84c50146e333838d688ee3f511f101cc07f94daa27ab399e5286a2c3399278e5da8c87fdc5ca36648504de2b338e45b6
+  languageName: node
+  linkType: hard
+
 "single-spa-react@npm:~5.0.0":
   version: 5.0.2
   resolution: "single-spa-react@npm:5.0.2"
@@ -20285,10 +20325,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"single-spa@npm:^5.9.2":
-  version: 5.9.5
-  resolution: "single-spa@npm:5.9.5"
-  checksum: 1ad1b5595dee49085c2d39e69b2bb3706ad58635a1f3616a5ba90793ec1dfe66c770ba33bcaf6dc2a87182eaac84b3da9b631b531a5696083052f884d0e07c1b
+"single-spa@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "single-spa@npm:6.0.0"
+  checksum: 4efc6248e5ba3b2c02090869a1d85c8fdb77994465d760233ff58462d35614503fefcb2330999b15ef7e43508181939a41628410912f9a1cc01860b192580d11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The PR is addressing the issue of the lab-panels-slot which will not be visible in the implementer tools UI when used below
 in the value for `ComponentContext.Provider` as the UI viewer depends on the div that cannot be added because of how the Carbon components work. Implementers can add more tab extensions to this slot via the routes.js file configuration.
## Screenshots
<img width="1045" alt="Screenshot 2024-01-23 at 12 02 19 PM" src="https://github.com/openmrs/openmrs-esm-laboratory/assets/46714226/daac8c4a-e2cd-4240-8e15-89538f772ca4">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
