### PR TITLE
Display orders for tests only

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -23,7 +23,7 @@ export const configSchema = {
   },
   laboratoryOrderTypeUuid: {
     _type: Type.String,
-    _default: "",
+    _default: "52a447d3-a64a-11e3-9aeb-50e549534c5e",
     _description: "Uuid for orderType",
   },
   laboratoryReferalDestinationUuid: {

--- a/src/work-list/work-list.resource.ts
+++ b/src/work-list/work-list.resource.ts
@@ -122,10 +122,10 @@ export function useGetOrdersWorklist(fulfillerStatus: string) {
 
   const orderTypeQuery =
     laboratoryOrderTypeUuid !== ""
-      ? `orderType=${laboratoryOrderTypeUuid}&`
+      ? `orderTypes=${laboratoryOrderTypeUuid}`
       : "";
 
-  const apiUrl = `${restBaseUrl}/order?orderTypes=52a447d3-a64a-11e3-9aeb-50e549534c5e&${orderTypeQuery}fulfillerStatus=${fulfillerStatus}&v=full`;
+  const apiUrl = `${restBaseUrl}/order?${orderTypeQuery}&fulfillerStatus=${fulfillerStatus}&v=full`;
 
   const mutateOrders = useCallback(
     () =>
@@ -133,7 +133,7 @@ export function useGetOrdersWorklist(fulfillerStatus: string) {
         (key) =>
           typeof key === "string" &&
           key.startsWith(
-            `/ws/rest/v1/order?orderType=${laboratoryOrderTypeUuid}`
+            `${restBaseUrl}/order?orderTypes=${laboratoryOrderTypeUuid}`
           )
       ),
     [laboratoryOrderTypeUuid]

--- a/src/work-list/work-list.resource.ts
+++ b/src/work-list/work-list.resource.ts
@@ -125,7 +125,7 @@ export function useGetOrdersWorklist(fulfillerStatus: string) {
       ? `orderType=${laboratoryOrderTypeUuid}&`
       : "";
 
-  const apiUrl = `${restBaseUrl}/order?${orderTypeQuery}fulfillerStatus=${fulfillerStatus}&v=full`;
+  const apiUrl = `${restBaseUrl}/order?orderTypes=52a447d3-a64a-11e3-9aeb-50e549534c5e&${orderTypeQuery}fulfillerStatus=${fulfillerStatus}&v=full`;
 
   const mutateOrders = useCallback(
     () =>


### PR DESCRIPTION
## Requirements

- [ ] The orders returns were both test orders and Medication orders, This PR fixes the issue to only retrieve test orders and not the medication orders are well. 

## Summary
Retrieve only test orders

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-laboratory/assets/20700222/da0f330c-6449-4195-b098-96ef72f4d381)


